### PR TITLE
fix: homepage icon grid layout

### DIFF
--- a/src/components/IconGrid/IconGrid.css
+++ b/src/components/IconGrid/IconGrid.css
@@ -257,6 +257,10 @@ figcaption > p {
 }
 
 @media screen and (max-width: 536px) {
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+  }
+
   .grid-item {
     width: 108px;
     height: unset;

--- a/src/components/IconGrid/IconGrid.css
+++ b/src/components/IconGrid/IconGrid.css
@@ -8,11 +8,9 @@
 }
 
 .grid {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   max-width: 1120px;
-  margin: auto;
 }
 
 .grid-item {

--- a/src/components/IconGrid/IconGrid.css
+++ b/src/components/IconGrid/IconGrid.css
@@ -11,6 +11,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   max-width: 1120px;
+  margin: auto;
 }
 
 .grid-item {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/73213399/236612834-87d4b80a-f5ba-48b2-9f8b-bb913a1e3181.png)

after:
![image](https://user-images.githubusercontent.com/73213399/236612842-9778da98-4e91-47b8-b42e-38c57abdb258.png)
