### PR TITLE
feat(app): add option to download raw svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phosphor-home",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "homepage": "https://phosphoricons.com",
   "author": {

--- a/src/components/IconGrid/IconGrid.css
+++ b/src/components/IconGrid/IconGrid.css
@@ -212,8 +212,9 @@ figcaption > p {
   align-items: center;
   justify-content: flex-start; */
   display: inline-grid;
-  grid-template-columns: 66px 66px 92px;
-  gap: 6px;
+  grid-template-columns: 1fr 1fr;
+  max-height: 60px;
+  /* gap: 6px; */
 }
 
 .action-button {
@@ -254,6 +255,10 @@ figcaption > p {
     height: 440px;
     margin-inline: -10px;
     border-radius: 0;
+  }
+
+  .detail-actions {
+    display: inline-flex;
   }
 }
 

--- a/src/components/IconGrid/Panel.tsx
+++ b/src/components/IconGrid/Panel.tsx
@@ -260,6 +260,18 @@ const Panel = () => {
     );
   };
 
+  const handleDownloadRawSVG = async () => {
+    if (!entry) return;
+
+    const { name } = entry;
+    saveAs(
+      `https://raw.githubusercontent.com/phosphor-icons/core/main/raw/${weight}/${name}${
+        weight === "regular" ? "" : `-${weight}`
+      }.svg`,
+      `${entry?.name}${weight === "regular" ? "" : `-${weight}`}.svg`
+    );
+  };
+
   const handleDownloadPNG = async (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
@@ -338,6 +350,13 @@ const Panel = () => {
                       title="Download SVG"
                       download
                       onClick={handleDownloadSVG}
+                    />
+
+                    <ActionButton
+                      label="SVG Raw"
+                      title="Download raw SVG including original strokes"
+                      download
+                      onClick={handleDownloadRawSVG}
                     />
 
                     <ActionButton


### PR DESCRIPTION
Adds a button to download Raw SVG, addressing #227 and #296 