### PR TITLE
feat(app): prepare for copy unicode functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
     "format": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,vue}\""
   },
   "dependencies": {
-    "@phosphor-icons/core": "^2.0.2",
+    "@phosphor-icons/core": "^2.0.4",
     "@phosphor-icons/react": "^2.0.15",
     "@recoiljs/refine": "^0.1.1",
     "file-saver": "^2.0.2",
-    "framer-motion": "^9.0.1",
+    "framer-motion": "^10.17.12",
     "fuse.js": "^6.4.1",
-    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropdown-select": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,vue}\""
   },
   "dependencies": {
-    "@phosphor-icons/core": "^2.0.4",
+    "@phosphor-icons/core": "^2.0.8",
     "@phosphor-icons/react": "^2.0.15",
     "@recoiljs/refine": "^0.1.1",
     "file-saver": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phosphor-icons/homepage",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "homepage": "https://phosphoricons.com",
   "author": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@phosphor-icons/core':
-    specifier: ^2.0.4
-    version: 2.0.4
+    specifier: ^2.0.8
+    version: 2.0.8
   '@phosphor-icons/react':
     specifier: ^2.0.15
     version: 2.0.15(react-dom@18.2.0)(react@18.2.0)
@@ -668,8 +668,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@phosphor-icons/core@2.0.4:
-    resolution: {integrity: sha512-VLSxdZvcplDn2afkxiDMrHbTFNudFwzxrplPqyU5a6uerqCHRl18kZ2yGFu7fI9ET+d1+kbYkdS02D24rMA6tA==}
+  /@phosphor-icons/core@2.0.8:
+    resolution: {integrity: sha512-I9MdTtqjqZDXwo6bbG5lRWZUJMWgXc70hZAVG1OVNVmb6j7039slVXLDH4VEok3U3h1Yhotxe8G5l4sPHJBDzQ==}
     dev: false
 
   /@phosphor-icons/react@2.0.15(react-dom@18.2.0)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   '@phosphor-icons/core':
-    specifier: ^2.0.2
+    specifier: ^2.0.4
     version: 2.0.4
   '@phosphor-icons/react':
     specifier: ^2.0.15
@@ -18,14 +18,11 @@ dependencies:
     specifier: ^2.0.2
     version: 2.0.5
   framer-motion:
-    specifier: ^9.0.1
-    version: 9.1.7(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^10.17.12
+    version: 10.17.12(react-dom@18.2.0)(react@18.2.0)
   fuse.js:
     specifier: ^6.4.1
     version: 6.6.2
-  prop-types:
-    specifier: ^15.8.1
-    version: 15.8.1
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -1043,11 +1040,16 @@ packages:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
     dev: false
 
-  /framer-motion@9.1.7(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-nKxBkIO4IPkMEqcBbbATxsVjwPYShKl051yhBv9628iAH6JLeHD0siBHxkL62oQzMC1+GNX73XtPjgP753ufuw==}
+  /framer-motion@10.17.12(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-6aaBLN2EgH/GilXwOzEalTfw5Rx9DTQJJjTrxq5bfDbGtPCzXz2GCN6ePGRpTi1ZGugLHxdU273h38ENbcdFKQ==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,7 +8,7 @@ import IconGrid from "@/components/IconGrid";
 import Footer from "@/components/Footer";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Notice from "@/components/Notice";
-import Recipes from "@/components/Recipes";
+// import Recipes from "@/components/Recipes";
 import { useCSSVariables } from "@/hooks";
 import { isDarkThemeSelector } from "@/state";
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -61,10 +61,8 @@ const Header = (_: HeaderProps) => {
               <a href="https://www.buymeacoffee.com/phosphoricons">
                 Buy Me a Coffee
               </a>
-              ! It takes a lot of work to make Phosphor available to the public
-              free and open-source, and your one-time or recurring contribution
-              does a lot to keep us going. Please show us some support if you
-              can!
+              ! Your one-time or recurring contribution does a lot to keep us
+              going. Please show us some support if you can!
             </small>
           </div>
         </Banner>

--- a/src/components/IconGrid/IconGrid.css
+++ b/src/components/IconGrid/IconGrid.css
@@ -10,7 +10,7 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  max-width: 1120px;
+  max-width: 1152px;
   margin: auto;
 }
 

--- a/src/components/IconGrid/IconGrid.tsx
+++ b/src/components/IconGrid/IconGrid.tsx
@@ -64,10 +64,15 @@ const IconGrid = (_: IconGridProps) => {
     <IconContext.Provider value={{ weight, size, color, mirrored: false }}>
       <div className="grid-container">
         <i id="beacon" className="beacon" />
-        <motion.div className="grid" initial="hidden" animate={controls}>
+        <motion.div
+          key={query}
+          className="grid"
+          initial="hidden"
+          animate={controls}
+        >
           {filteredQueryResults.map((iconEntry, index) => (
             <IconGridItem
-              key={index}
+              key={iconEntry.name}
               index={index}
               isDark={isDark}
               entry={iconEntry}

--- a/src/components/IconGrid/IconGridItem.tsx
+++ b/src/components/IconGrid/IconGridItem.tsx
@@ -20,7 +20,7 @@ interface IconGridItemProps extends HTMLAttributes<HTMLDivElement> {
 
 const transition = { duration: 0.2 };
 const originIndex = 0;
-const delayPerPixel = 0.0004;
+const delayPerPixel = 0.0003;
 
 const itemVariants = {
   hidden: { opacity: 0 },
@@ -68,30 +68,28 @@ const IconGridItem = (props: IconGridItemProps) => {
   }, [originOffset]);
 
   return (
-    <>
-      <motion.div
-        className="grid-item"
-        key={name}
-        ref={ref}
-        tabIndex={0}
-        style={{
-          ...style,
-          backgroundColor: isOpen ? "var(--background-layer)" : undefined,
-        }}
-        custom={delayRef}
-        transition={transition}
-        variants={itemVariants}
-        onKeyPress={(e) => e.key === "Enter" && handleOpen()}
-        onClick={handleOpen}
-      >
-        <Icon />
-        <p>
-          <span className="name">{name}</span>
-          {isNew && <span className="badge new">•</span>}
-          {isUpdated && <span className="badge updated">•</span>}
-        </p>
-      </motion.div>
-    </>
+    <motion.div
+      className="grid-item"
+      key={name}
+      ref={ref}
+      tabIndex={0}
+      style={{
+        ...style,
+        backgroundColor: isOpen ? "var(--background-layer)" : undefined,
+      }}
+      custom={delayRef}
+      transition={transition}
+      variants={itemVariants}
+      onKeyPress={(e) => e.key === "Enter" && handleOpen()}
+      onClick={handleOpen}
+    >
+      <Icon />
+      <p>
+        <span className="name">{name}</span>
+        {isNew && <span className="badge new">•</span>}
+        {isUpdated && <span className="badge updated">•</span>}
+      </p>
+    </motion.div>
   );
 };
 

--- a/src/components/IconGrid/Panel.tsx
+++ b/src/components/IconGrid/Panel.tsx
@@ -351,9 +351,9 @@ const Panel = () => {
               <entry.Icon ref={ref} size={64}></entry.Icon>
               <figcaption>
                 <p>{entry.name}</p>
-                <small className="versioning">
+                {/* <small className="versioning">
                   U+{entry.codepoint.toString(16).toUpperCase()}
-                </small>
+                </small> */}
                 <small className="versioning">
                   available in v{entry.published_in.toFixed(1)}.0+
                 </small>
@@ -415,13 +415,13 @@ const Panel = () => {
                       onClick={handleCopyDataSVG}
                     />
 
-                    <ActionButton
+                    {/* <ActionButton
                       label="Unicode"
                       title="Copy Unicode character (v2.1.0 or newer)"
                       active={copied === CopyType.UNICODE}
                       disabled={weight === IconStyle.DUOTONE}
                       onClick={handleCopyUnicode}
-                    />
+                    /> */}
                   </>
                 )}
               </div>

--- a/src/components/IconGrid/Panel.tsx
+++ b/src/components/IconGrid/Panel.tsx
@@ -18,6 +18,7 @@ import {
   CaretDoubleLeft,
   CaretDoubleRight,
 } from "@phosphor-icons/react";
+import { IconStyle } from "@phosphor-icons/core";
 import ReactGA from "react-ga4";
 
 import Tabs, { Tab } from "@/components/Tabs";
@@ -61,6 +62,7 @@ enum CopyType {
   SVG_DATA,
   PNG,
   PNG_DATA,
+  UNICODE,
 }
 
 function cloneWithSize(svg: SVGSVGElement, size: number): SVGSVGElement {
@@ -75,12 +77,18 @@ const ActionButton = (
     active?: boolean;
     label: string;
     download?: boolean;
+    disabled?: boolean;
   } & HTMLAttributes<HTMLButtonElement>
 ) => {
   const { active, download, label, ...rest } = props;
   const Icon = download ? ArrowFatLinesDown : Copy;
   return (
-    <button {...rest} className="action-button text" tabIndex={0}>
+    <button
+      {...rest}
+      className={`action-button text ${props.disabled ? "disabled" : ""}`}
+      aria-disabled={props.disabled}
+      tabIndex={0}
+    >
       {active ? (
         <CheckCircle size={20} color="var(--olive)" weight="fill" />
       ) : (
@@ -246,6 +254,14 @@ const Panel = () => {
     setCopied(CopyType.SVG_RAW);
   };
 
+  const handleCopyUnicode = async () => {
+    if (!entry) return;
+
+    const content = String.fromCharCode(entry.codepoint);
+    navigator.clipboard?.writeText(content);
+    setCopied(CopyType.UNICODE);
+  };
+
   const handleDownloadSVG = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
@@ -336,6 +352,9 @@ const Panel = () => {
               <figcaption>
                 <p>{entry.name}</p>
                 <small className="versioning">
+                  U+{entry.codepoint.toString(16).toUpperCase()}
+                </small>
+                <small className="versioning">
                   available in v{entry.published_in.toFixed(1)}.0+
                 </small>
               </figcaption>
@@ -394,6 +413,14 @@ const Panel = () => {
                       title="Copy SVG as DataURL"
                       active={copied === CopyType.SVG_DATA}
                       onClick={handleCopyDataSVG}
+                    />
+
+                    <ActionButton
+                      label="Unicode"
+                      title="Copy Unicode character (v2.1.0 or newer)"
+                      active={copied === CopyType.UNICODE}
+                      disabled={weight === IconStyle.DUOTONE}
+                      onClick={handleCopyUnicode}
                     />
                   </>
                 )}

--- a/src/components/Links/Links.tsx
+++ b/src/components/Links/Links.tsx
@@ -90,7 +90,7 @@ const Links = (_: LinksProps) => {
             href="https://www.buymeacoffee.com/phosphoricons"
             eventLabel="Donate"
           >
-            Donate on BuyMeACoffee
+            Donate
           </OutboundLink>
           {" / "}
           <OutboundLink

--- a/src/state/RecoilSyncLocalStorage.tsx
+++ b/src/state/RecoilSyncLocalStorage.tsx
@@ -42,6 +42,7 @@ export default ({ children }: { children: ReactNode }) => {
 
   const listen: ListenToItems = useCallback(
     ({ updateItem, updateAllKnownItems }) => {
+      void updateAllKnownItems;
       const onStorage = (event: StorageEvent) => {
         // ignore clear() calls
         if (event.storageArea === localStorage && event.key !== null) {


### PR DESCRIPTION
- Adds (but does not yet enable) unicode codepoint copy functionality
- Updates to @phosphor-icons/core@2.0.8, fixing #420: `file-magnifying-glass` inadvertently had its name and alias (`file-search`) mixed up