### PR TITLE
Add compose-phosphor-icon to Community Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ReactDOM.render(<App />, document.getElementById("root"));
 - [phosphor-leptos](https://github.com/SorenHolstHansen/phosphor-leptos) ▲ Phosphor icon component library for Leptos apps (rust)
 - [wordpress-phosphor-icons-block](https://github.com/robruiz/phosphor-icons-block) ▲ Phosphor icon block for use in WordPress v5.8+
 - [ember-phosphor-icons](https://github.com/IgnaceMaes/ember-phosphor-icons) ▲ Phosphor icons for Ember apps
+- [compose-phosphor-icons](https://github.com/adamglin0/compose-phosphor-icon) ▲ Phosphor icons for Compose Multiplatform
 
 If you've made a port of Phosphor and you want to see it here, just open a PR [here](https://github.com/phosphor-icons/homepage)!
 


### PR DESCRIPTION
A kotlin platform library for using phosphor icon in compose multiplatform.