### PR TITLE
fix(footer): fix dead Manrope link

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -160,7 +160,7 @@ const Footer = (_: FooterProps) => {
           <div className="fine-print">
             <p>
               Type set in{" "}
-              <a className="main-link" href="https://www.gent.media/manrope">
+              <a className="main-link" href="https://fonts.google.com/specimen/Manrope">
                 Manrope
               </a>{" "}
               by Mikhail Sharanda and{" "}


### PR DESCRIPTION
It seems the Manrope font site is defunct. Replace with Google Fonts link.
Resolves: #1072 