### PR TITLE
Add link to community Latex port braniii/phosphoricons

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ ReactDOM.render(<App />, document.getElementById("root"));
 - [SorenHolstHansen/phosphor-leptos](https://github.com/SorenHolstHansen/phosphor-leptos) ▲ Phosphor icon component library for Leptos apps (Rust)
 - [vnphanquang/phosphor-icons-tailwindcss](https://github.com/vnphanquang/phosphor-icons-tailwindcss) ▲ TailwindCSS plugin for Phosphor icons
 - [wireui/phosphoricons](https://github.com/wireui/phosphoricons) ▲ Phosphor icons for Laravel
+- [braniii/phosphoricons](github.com/braniii/phosphoricons) ▲ Phosphor icons for LaTex, LuaLaTex, and XeLaTex
 
 If you've made a port of Phosphor and you want to see it here, just open a PR [here](https://github.com/phosphor-icons/homepage)!
 


### PR DESCRIPTION
Hi, this pull request adds a new port [braniii/phosphoricons](https://github.com/braniii/phosphoricons) of Phosphor icons to the community list. The port is a LaTeX, LuaLaTeX, and XeLaTeX port and is uploaded to the central Latex package system ctan.org as [phosphoricons](https://ctan.org/pkg/phosphoricons).
Thx for the create icons :)